### PR TITLE
Libre Office fails because it uses X11, drop it

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -184,7 +184,6 @@ parts:
     plugin: nil
     stage-packages:
       - glmark2-es2-wayland
-      - libreoffice-gtk3
 
   kodi:
     plugin: ppa


### PR DESCRIPTION
Libre Office fails because it uses X11, drop it.

It also make the snap bigger and confuses review-tools.