### PR TITLE
Fix /usr/share/glmark2 for glmark2-es2-wayland use

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,6 +35,8 @@ layout:
     bind: $SNAP/usr/share/kodi
   /usr/share/games:
     bind: $SNAP/usr/share/games
+  /usr/share/glmark2:
+    bind: $SNAP/usr/share/glmark2
   /usr/share/X11/xkb:
     bind: $SNAP/usr/share/X11/xkb
   /usr/share/fonts:


### PR DESCRIPTION
Fix /usr/share/glmark2 for glmark2-es2-wayland use. (Fixes #10)