### PR TITLE
Don't overwrite existing files in /tmp/.X11-unix/

### DIFF
--- a/glue/hacks/setup-x11
+++ b/glue/hacks/setup-x11
@@ -3,17 +3,16 @@
 # Attempt set up for X11 support (but we don't stop if that fails)
 set +e
 mkdir -p /tmp/.X11-unix
+chmod 777 /tmp/.X11-unix
 # We need to stop Mir accessing any existing X11 session.
 # Mir detects existing sessions by scanning /tmp/.X11-unix
 # but we don't have the real /tmp, but a snap specific one.
 # So fake the existing $DISPLAY in the fake /tmp/.X11-unix
-if [ -z "${DISPLAY}" ]
-then touch /tmp/.X11-unix/X${DISPLAY:1}
-fi
-# A few more for luck
-touch /tmp/.X11-unix/X0
-touch /tmp/.X11-unix/X1
-touch /tmp/.X11-unix/X2
-touch /tmp/.X11-unix/X3
-touch /tmp/.X11-unix/X4
+# (we also fake a few likely sockets [0-4] for luck)
+for x in ${DISPLAY:1} 0 1 2 3 4
+do
+  if [ ! -e /tmp/.X11-unix/X${x} ]; then
+    touch   /tmp/.X11-unix/X${x}
+  fi
+done
 set -e


### PR DESCRIPTION
There are changes afoot with the X11 interface. (See snapcore/snapd#9530)

This avoids trampling on real content in /tmp/.X11-unix/